### PR TITLE
Add missing AppsFlyerAdRevenue.asmdef.meta file

### DIFF
--- a/AppsFlyerAdRevenue.asmdef.meta
+++ b/AppsFlyerAdRevenue.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad55e82376adbd545ae20d7cdd9ba472
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds the missing .meta file not included in the fix to issue #12
